### PR TITLE
fix to setup layout when spriteOnly is true

### DIFF
--- a/Assets/MYTYKit/Scripts/Util/AssetImporter.cs
+++ b/Assets/MYTYKit/Scripts/Util/AssetImporter.cs
@@ -69,12 +69,13 @@ public class AssetImporter : MonoBehaviour
 
         selector.id = 0;
         selector.Configure();
-        if (spriteOnly) yield break;
 
         request = m_assetBundle.LoadAssetAsync<DefaultLayoutAsset>("DefaultLayoutAsset.asset");
         yield return request;
         var layout = request.asset as DefaultLayoutAsset;
         SetupLayout(root, selector, layout);
+
+        if (spriteOnly) yield break;
 
         yield return SetupAvatarAsync(root, avatarSelectorGO, motionTemplateGO);
 


### PR DESCRIPTION
Applying v0.2.0-rc3 on MYTYCamera, found bug that reference camera doesn't applied when loading thumbnails

I applied this to MYTYCamera when applying reference camera.

I'd appreciate it if you could apply this to MYTY kit code if there's no problem!