### PR TITLE
Skip if headbone is not defined

### DIFF
--- a/Assets/MYTYKit/Scripts/Util/AvatarImporter/MYTYAvatarImporterV2.cs
+++ b/Assets/MYTYKit/Scripts/Util/AvatarImporter/MYTYAvatarImporterV2.cs
@@ -133,6 +133,7 @@ namespace MYTYKit.AvatarImporter
             int idx = 0;
             foreach (var item in asset.items)
             {
+                if(item.headBone == null) continue;
                 var parentBoneList = new List<GameObject>();
                 var currBone = goMap[item.headBone];
                 do


### PR DESCRIPTION
When loading avatars generated in v1.0.0, errors occurred since there is no defined headbone for ar items

So, I thought it's better to skip, since we can load avatars generated on lower versions