### PR TITLE
feat: Add callback function parameter to LoadMainBody & LoadTrait

### DIFF
--- a/Assets/MYTYKit/Scripts/Util/AvatarImporter/MYTY3DAvatarImporter.cs
+++ b/Assets/MYTYKit/Scripts/Util/AvatarImporter/MYTY3DAvatarImporter.cs
@@ -79,7 +79,7 @@ namespace MYTYKit.AvatarImporter
             });
         }
 
-        public void LoadTrait(byte[] bytes, string loadName, Action traitLoaded)
+        public void LoadTrait(byte[] bytes, string loadName, Action traitLoaded = null)
         {
             if (m_avatarRoot == null)
             {
@@ -94,7 +94,7 @@ namespace MYTYKit.AvatarImporter
                 driver.binder.Bind(rootBone);
                 driver.CheckAndSetupBlendShape(instance.transform);
                 m_rootBoneMap[instance.transform] = rootBone;
-                traitLoaded.Invoke();
+                traitLoaded?.Invoke();
             });
            
            

--- a/Assets/MYTYKit/Scripts/Util/AvatarImporter/MYTY3DAvatarImporter.cs
+++ b/Assets/MYTYKit/Scripts/Util/AvatarImporter/MYTY3DAvatarImporter.cs
@@ -35,7 +35,7 @@ namespace MYTYKit.AvatarImporter
 
         
         
-        public void LoadMainbody(byte[] modelData, string jsonString)
+        public void LoadMainbody(byte[] modelData, string jsonString, Action<GameObject> avatarLoaded)
         {
             if (driver == null)
             {
@@ -75,11 +75,11 @@ namespace MYTYKit.AvatarImporter
                 driver.CheckAndSetupBlendShape(m_avatarRoot);
                 driver.humanoidAvatarRoot = m_avatarRoot;
                 driver.Initialize();
-
+                avatarLoaded.Invoke(m_avatarRoot.gameObject);
             });
         }
 
-        public void LoadTrait(byte[] bytes, string loadName)
+        public void LoadTrait(byte[] bytes, string loadName, Action traitLoaded)
         {
             if (m_avatarRoot == null)
             {
@@ -94,6 +94,7 @@ namespace MYTYKit.AvatarImporter
                 driver.binder.Bind(rootBone);
                 driver.CheckAndSetupBlendShape(instance.transform);
                 m_rootBoneMap[instance.transform] = rootBone;
+                traitLoaded.Invoke();
             });
            
            


### PR DESCRIPTION
While implementing 3D loading from application side, realized that there's no way to recognize the end of GLB loading

@apsntian Please take a look at it. I just simply added loading functions to receive callback functions.

For `LoadMainBody`, used `Action<GameObject>` to let application can get the reference of loaded avatar

since application already know the reference when `LoadTrait` is called, `LoadTrait` only receives `Action`