### PR TITLE
fix: Move ShaderMap assignment to Awake function

### DIFF
--- a/Assets/MYTYKit/Scripts/Util/AvatarImporter/MASImporter.cs
+++ b/Assets/MYTYKit/Scripts/Util/AvatarImporter/MASImporter.cs
@@ -53,7 +53,7 @@ namespace MYTYKit.AvatarImporter
         string m_id;
 
 
-        void Start()
+        void Awake()
         {
             m_shaderMap = Resources.Load<ShaderMapAsset>("ShaderMap");
         }


### PR DESCRIPTION
MASImporter is dynamically created in runtime, so there might be a chance to call other functions before shaderMap is properly assigned.
So, moved it to Awake function to make sure shaderMap is properly assigned before calling any functions of MASImporter